### PR TITLE
Animate dark mode toggle

### DIFF
--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion as Motion } from "framer-motion";
+import { motion as Motion, AnimatePresence } from "framer-motion";
 import {
   Github,
   Linkedin,
@@ -140,7 +140,18 @@ const DarkModeToggle = () => {
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
       className="rounded-lg border p-2 hover:bg-accent/50"
     >
-      {theme === "dark" ? <Sun className="size-4" /> : <Moon className="size-4" />}
+      <AnimatePresence initial={false} mode="wait">
+        <Motion.span
+          key={theme}
+          initial={{ rotate: -90, opacity: 0 }}
+          animate={{ rotate: 0, opacity: 1 }}
+          exit={{ rotate: 90, opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          className="block"
+        >
+          {theme === "dark" ? <Sun className="size-4" /> : <Moon className="size-4" />}
+        </Motion.span>
+      </AnimatePresence>
     </button>
   );
 };

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -2,6 +2,16 @@ html {
   scroll-behavior: smooth;
 }
 
+*, *::before, *::after {
+  @apply transition-colors duration-300;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition: none;
+  }
+}
+
 :root {
   --background: 0 0% 100%;
   --foreground: 222.2 47.4% 11.2%;


### PR DESCRIPTION
## Summary
- animate sun/moon icon in dark mode toggle
- add color transition for smoother light/dark theme changes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bdac17aa0832fbe7b51dc9f1b8c1c